### PR TITLE
Updated debug examples from main repo.

### DIFF
--- a/examples/debug/debug camera.js
+++ b/examples/debug/debug camera.js
@@ -1,20 +1,40 @@
-var sprite;
-var spriteB;
-var counter = 0;
-var step = Math.PI * 2 / 360;
-var game = new Phaser.Game(800, 600, Phaser.CANVAS, "phaser-example", {
-    preload: function () { return game.load.image("sprite", "assets/sprites/phaser2.png"); },
-    create: function () {
-        sprite = game.add.sprite(0, 0, "sprite");
-        sprite.alpha = 0.5;
-        sprite.x = game.width / 2;
-        sprite.anchor.x = sprite.anchor.y = 0.5;
-    },
-    update: function () {
-        var tStep = Math.sin(counter);
-        sprite.y = (game.height / 2) + tStep * 30;
-        sprite.rotation += Phaser.Math.degToRad(0.1 * tStep);
-        counter += step;
-    },
-    render: function () { return game.debug.cameraInfo(game.camera, 32, 32); }
-});
+
+var game = new Phaser.Game(800, 600, Phaser.CANVAS, 'phaser-example', { preload: preload, create: create, update:update, render:render  });
+
+var sprite, spriteB ;
+var counter = 0 ;
+var step = Math.PI * 2 / 360 ;
+
+
+function preload() {
+
+    // Load images to use as the game sprites
+    game.load.image('sprite', 'assets/sprites/phaser2.png');
+
+}
+
+function create() {
+
+    // Create sprite and put it in the middle of the stage
+    sprite = game.add.sprite(0, 0, 'sprite');
+    sprite.alpha = 0.5 ;
+    sprite.x = game.width / 2 ;
+    sprite.anchor.x = sprite.anchor.y = 0.5 ;
+
+}
+
+function update()
+{
+    // Move sprite up and down smoothly for show
+    var tStep = Math.sin( counter ) ;
+    sprite.y = (game.height/2) + tStep * 30 ;
+    sprite.rotation += Phaser.Math.degToRad( 0.1 * tStep ) ;
+    counter += step ;
+}
+
+function render() {
+
+    // Camera
+    game.debug.cameraInfo(game.camera, 32, 32);
+
+}

--- a/examples/debug/debug display.js
+++ b/examples/debug/debug display.js
@@ -1,21 +1,41 @@
-var sprite;
-var counter = 0;
-var step = Math.PI * 2 / 360;
-var game = new Phaser.Game(800, 600, Phaser.CANVAS, "phaser-example", {
-    preload: function () { return game.load.image("sprite", "assets/sprites/phaser2.png"); },
-    create: function () {
-        sprite = game.add.sprite(0, 0, "sprite");
-        sprite.alpha = 0.5;
-        sprite.x = game.width / 2;
-        sprite.anchor.x = sprite.anchor.y = 0.5;
-    },
-    update: function () {
-        var tStep = Math.sin(counter);
-        sprite.y = (game.height / 2) + tStep * 30;
-        sprite.rotation += Phaser.Math.degToRad(0.1 * tStep);
-        counter += step;
-    },
-    render: function () {
-        game.debug.spriteBounds(sprite);
-    }
-});
+
+var game = new Phaser.Game(800, 600, Phaser.CANVAS, 'phaser-example', { preload: preload, create: create, update:update, render:render  });
+
+var sprite ;
+var counter = 0 ;
+var step = Math.PI * 2 / 360 ;
+
+
+function preload() {
+
+    // Load images to use as the game sprites
+    game.load.image('sprite', 'assets/sprites/phaser2.png');
+
+}
+
+function create() {
+
+    // Create sprite and put it in the middle of the stage
+    sprite = game.add.sprite(0, 0, 'sprite');
+    sprite.alpha = 0.5 ;
+    sprite.x = game.width / 2 ;
+    sprite.anchor.x = sprite.anchor.y = 0.5 ;
+
+}
+
+function update()
+{
+    // Move sprite up and down smoothly for show
+    var tStep = Math.sin( counter ) ;
+    sprite.y = (game.height/2) + tStep * 30 ;
+    sprite.rotation += Phaser.Math.degToRad( 0.1 * tStep ) ;
+    counter += step ;
+}
+
+function render() {
+
+    // Display
+    game.debug.spriteBounds(sprite);
+    game.debug.spriteCorners(sprite, true, true);
+
+}

--- a/examples/debug/debug draw.js
+++ b/examples/debug/debug draw.js
@@ -1,12 +1,18 @@
-var rect = new Phaser.Rectangle(100, 100, 100, 100);
-var circle = new Phaser.Circle(280, 150, 100);
-var point = new Phaser.Point(100, 280);
-var game = new Phaser.Game(800, 600, Phaser.CANVAS, "phaser-example", {
-    render: function () {
-        game.debug.geom(rect, "rgba(255,0,0,1)");
-        game.debug.geom(circle, "rgba(255,255,0,1)");
-        game.debug.geom(point, "rgba(255,255,255,1)");
-        game.debug.pixel(200, 280, "rgba(0,255,255,1)");
-        game.debug.text("This is debug text", 100, 380);
-    }
-});
+
+var game = new Phaser.Game(800, 600, Phaser.CANVAS, 'phaser-example', { render:render  });
+
+var rect = new Phaser.Rectangle( 100, 100, 100, 100 ) ;
+var circle = new Phaser.Circle( 280, 150, 100 ) ;
+var point = new Phaser.Point( 100, 280 ) ;
+
+function render() {
+
+    // Draw debug tools
+    game.debug.geom( rect, 'rgba(255,0,0,1)' ) ;
+    game.debug.geom( circle, 'rgba(255,255,0,1)' ) ;
+    game.debug.geom( point, 'rgba(255,255,255,1)' ) ;
+    game.debug.pixel( 200, 280, 'rgba(0,255,255,1)' ) ;
+    game.debug.text( "This is debug text", 100, 380 );
+
+
+}

--- a/examples/debug/debug input.js
+++ b/examples/debug/debug input.js
@@ -1,24 +1,41 @@
-var sprite;
-var counter = 0;
-var step = Math.PI * 2 / 360;
-var game = new Phaser.Game(800, 600, Phaser.CANVAS, "phaser-example", {
-    preload: function () { return game.load.image("sprite", "assets/sprites/phaser2.png"); },
-    create: function () {
-        sprite = game.add.sprite(0, 0, "sprite");
-        sprite.alpha = 0.5;
-        sprite.x = game.width / 2;
-        sprite.anchor.x = sprite.anchor.y = 0.5;
-        sprite.inputEnabled = true;
-    },
-    update: function () {
-        var tStep = Math.sin(counter);
-        sprite.y = (game.height / 2) + tStep * 30;
-        sprite.rotation += Phaser.Math.degToRad(0.1 * tStep);
-        counter += step;
-    },
-    render: function () {
-        game.debug.inputInfo(32, 32);
-        game.debug.spriteInputInfo(sprite, 32, 130);
-        game.debug.pointer(game.input.activePointer);
-    }
-});
+
+var game = new Phaser.Game(800, 600, Phaser.CANVAS, 'phaser-example', { preload: preload, create: create, update: update, render: render  });
+
+var sprite ;
+var counter = 0 ;
+var step = Math.PI * 2 / 360 ;
+
+function preload() {
+
+    // Load images to use as the game sprites
+    game.load.image('sprite', 'assets/sprites/phaser2.png');
+
+}
+
+function create() {
+
+    // Create sprite and put it in the middle of the stage
+    sprite = game.add.sprite(0, 0, 'sprite');
+    sprite.alpha = 0.5 ;
+    sprite.x = game.width / 2 ;
+    sprite.anchor.x = sprite.anchor.y = 0.5 ;
+    sprite.inputEnabled = true ;
+}
+
+function update()
+{
+    // Move sprite up and down smoothly for show
+    var tStep = Math.sin( counter ) ;
+    sprite.y = (game.height/2) + tStep * 30 ;
+    sprite.rotation += Phaser.Math.degToRad( 0.1 * tStep ) ;
+    counter += step ;
+}
+
+function render() {
+
+    // Input debug info
+    game.debug.inputInfo(32, 32);
+    game.debug.spriteInputInfo(sprite, 32, 130);
+    game.debug.pointer( game.input.activePointer );
+
+}

--- a/examples/debug/debug physics.js
+++ b/examples/debug/debug physics.js
@@ -1,20 +1,37 @@
+
+var game = new Phaser.Game(800, 600, Phaser.CANVAS, 'phaser-example', { preload: preload, create: create, update: update, render: render  });
+
 var sprite;
 var counter = 0;
 var step = Math.PI * 2 / 360;
-var game = new Phaser.Game(800, 600, Phaser.CANVAS, "phaser-example", {
-    preload: function () { return game.load.image("sprite", "assets/sprites/phaser2.png"); },
-    create: function () {
-        game.physics.startSystem(Phaser.Physics.ARCADE);
-        sprite = game.add.sprite(game.world.centerX, game.world.centerY, "sprite");
-        sprite.anchor.set(0.5);
-        game.physics.arcade.enable(sprite);
-    },
-    update: function () {
-        var tStep = Math.sin(counter);
-        sprite.body.y = 120 + tStep * 60;
-        counter += step;
-    },
-    render: function () {
-        game.debug.body(sprite);
-    }
-});
+
+function preload() {
+
+    game.load.image('sprite', 'assets/sprites/phaser2.png');
+
+}
+
+function create() {
+
+    game.physics.startSystem(Phaser.Physics.ARCADE);
+
+    sprite = game.add.sprite(game.world.centerX, game.world.centerY, 'sprite');
+    sprite.anchor.set(0.5);
+
+    game.physics.arcade.enable(sprite);
+    
+}
+
+function update()
+{
+    // Move sprite up and down smoothly for show
+    var tStep = Math.sin(counter);
+    sprite.body.y = 120 + tStep * 60;
+    counter += step;
+}
+
+function render() {
+
+    game.debug.body(sprite);
+
+}

--- a/examples/debug/debug sprite.js
+++ b/examples/debug/debug sprite.js
@@ -1,19 +1,39 @@
-var sprite;
-var counter = 0;
-var step = Math.PI * 2 / 360;
-var game = new Phaser.Game(800, 600, Phaser.CANVAS, "phaser-example", {
-    preload: function () { return game.load.image("sprite", "assets/sprites/phaser2.png"); },
-    create: function () {
-        sprite = game.add.sprite(0, 0, "sprite");
-        sprite.alpha = 0.5;
-        sprite.x = game.width / 2;
-        sprite.anchor.x = sprite.anchor.y = 0.5;
-    },
-    update: function () {
-        var tStep = Math.sin(counter);
-        sprite.y = (game.height / 2) + tStep * 30;
-        sprite.rotation += Phaser.Math.degToRad(0.1 * tStep);
-        counter += step;
-    },
-    render: function () { return game.debug.spriteInfo(sprite, 32, 32); }
-});
+
+var game = new Phaser.Game(800, 600, Phaser.CANVAS, 'phaser-example', { preload: preload, create: create, update:update, render:render  });
+
+var sprite ;
+var counter = 0 ;
+var step = Math.PI * 2 / 360 ;
+
+
+function preload() {
+
+    // Load images to use as the game sprites
+    game.load.image('sprite', 'assets/sprites/phaser2.png');
+
+}
+
+function create() {
+
+    // Create sprite and put it in the middle of the stage
+    sprite = game.add.sprite(0, 0, 'sprite');
+    sprite.alpha = 0.5 ;
+    sprite.x = game.width / 2 ;
+    sprite.anchor.x = sprite.anchor.y = 0.5 ;
+}
+
+function update()
+{
+    // Move sprite up and down smoothly for show
+    var tStep = Math.sin( counter ) ;
+    sprite.y = (game.height/2) + tStep * 30 ;
+    sprite.rotation += Phaser.Math.degToRad( 0.1 * tStep ) ;
+    counter += step ;
+}
+
+function render() {
+
+    // Sprite debug info
+    game.debug.spriteInfo(sprite, 32, 32);
+
+}


### PR DESCRIPTION
I've updated the JS files from the main examples repo.

No functional changes were made to these files, with the exception of **debug display** which you already have a note about spriteCorners missing from the TypeScript definitions.

I've asked on the Phaser forums (but need my post to be approved by a moderator) on whether the official examples are actually wrong, and if that call should be removed.

Related to #28.
